### PR TITLE
[BPM-285] 가입 및 로그인 로직 수정

### DIFF
--- a/presentation/src/main/java/com/team/bpm/presentation/ui/intro/splash/SplashActivity.kt
+++ b/presentation/src/main/java/com/team/bpm/presentation/ui/intro/splash/SplashActivity.kt
@@ -30,8 +30,8 @@ import com.team.bpm.presentation.base.use
 import com.team.bpm.presentation.compose.BPMSpacer
 import com.team.bpm.presentation.compose.getLocalContext
 import com.team.bpm.presentation.compose.theme.MainBlackColor
-import com.team.bpm.presentation.ui.main.MainActivity
 import com.team.bpm.presentation.ui.intro.sign_up.SignUpActivity
+import com.team.bpm.presentation.ui.main.MainActivity
 import com.team.bpm.presentation.util.showToast
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -74,24 +74,33 @@ private fun SplashActivityContent(
 
                 is SplashContract.Effect.GetKakaoUserInfo -> {
                     val kakaoLoginInstance = UserApiClient.instance
-                    kakaoLoginInstance.loginWithKakaoAccount(context) { loginInfo, error ->
-                        if (loginInfo != null) {
-                            kakaoLoginInstance.me { user, _->
+                    kakaoLoginInstance.loginWithKakaoTalk(context) { kakaoTalkLoginInfo, _ ->
+                        kakaoTalkLoginInfo?.let {
+                            kakaoLoginInstance.me { user, _ ->
                                 user?.id?.let { kakaoId ->
-                                    user.kakaoAccount?.profile?.nickname?.let { kakaoNickname ->
-                                        event.invoke(
-                                            SplashContract.Event.OnSuccessKakaoLogin(
-                                                kakaoId,
-                                                kakaoNickname
-                                            )
-                                        )
+                                    user.kakaoAccount?.profile?.nickname?.let { kakaoNickName ->
+                                        event.invoke(SplashContract.Event.OnSuccessKakaoLogin(kakaoId, kakaoNickName))
+                                    } ?: run {
+                                        event.invoke(SplashContract.Event.OnSuccessKakaoLogin(kakaoId, ""))
+                                    }
+                                }
+                            }
+                        } ?: run {
+                            kakaoLoginInstance.loginWithKakaoAccount(context) { kakaoAccountLoginInfo, _ ->
+                                kakaoAccountLoginInfo?.let {
+                                    kakaoLoginInstance.me { user, _ ->
+                                        user?.id?.let { kakaoId ->
+                                            user.kakaoAccount?.profile?.nickname?.let { kakaoNickName ->
+                                                event.invoke(SplashContract.Event.OnSuccessKakaoLogin(kakaoId, kakaoNickName))
+                                            } ?: run {
+                                                event.invoke(SplashContract.Event.OnSuccessKakaoLogin(kakaoId, ""))
+                                            }
+                                        }
                                     }
                                 } ?: run {
                                     event.invoke(SplashContract.Event.OnFailureKakaoLogin)
                                 }
                             }
-                        } else {
-                            event.invoke(SplashContract.Event.OnFailureKakaoLogin)
                         }
                     }
                 }

--- a/presentation/src/main/java/com/team/bpm/presentation/ui/intro/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/team/bpm/presentation/ui/intro/splash/SplashViewModel.kt
@@ -10,15 +10,7 @@ import com.team.bpm.domain.usecase.user.SetUserIdUseCase
 import com.team.bpm.presentation.base.BaseViewModelV2
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
@@ -154,8 +146,7 @@ class SplashViewModel @Inject constructor(
                         _effect.emit(SplashContract.Effect.ShowToast("로그인에 실패하였습니다. 다시 시도해 주세요."))
                     }
                 }
-            }
+            }.collect()
         }
-
     }
 }


### PR DESCRIPTION
카카오톡 로그인 시도 후 성공 시 가입 또는 로그인으로 연결하고,
실패 시 카카오 계정으로 로그인 시도하도록 플로우를 수정하였습니다!